### PR TITLE
fix some old node cannot chainning the message

### DIFF
--- a/src/chain/validators-impl.ts
+++ b/src/chain/validators-impl.ts
@@ -27,7 +27,10 @@ export class ValidatorsImpl<Chain> implements Validators<Chain> {
   }
 
   withMessage(message: any) {
-    this.lastValidator.message = message;
+    this.lastValidator = {
+        ...this.lastValidator,
+        message: message
+    }
     return this.chain;
   }
 


### PR DESCRIPTION
on some old node, the chainning message validator not working.
fix this by copy the object and assign message using object destruction

## Description

<!-- Describe what you changed and link to the relevant issue(s) -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [ ] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [ ] This pull request is ready to merge.
